### PR TITLE
Don't forward the x-death header

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before :each do
+    Velveteen::Config.connection.queues.clear
+  end
 end


### PR DESCRIPTION
The x-death header is specific to a single message and should not be
propagated.

Also configures RSpec to clear the BunnyMock queue cache before each
spec, because it will cache queues based on name and leak data from one
spec into another.

Resolves #7 

Are there others headers that should be ignored as well?