### PR TITLE
Don't symbolize keys from JSON bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Within the worker, you have access to the following:
 
 * `message` - A representation of the Rabbit message, which responds to:
   * `body` - the raw message body
-  * `data` - the parsed JSON representation of the body
+  * `data` - the parsed JSON representation of the body - hashes will have
+    string keys
   * `delivery_info` - the delivery info from Rabbit
-  * `headers` - the headers from Rabbit, from `properties.headers`
+  * `headers` - the headers from Rabbit, from `properties.headers` - hashes will
+    have string keys
   * `properties` - the properties Rabbit
 * `publish(payload, [options])` - Publishes the message to the exchange
   * `payload` - the message body

--- a/example/worker.rb
+++ b/example/worker.rb
@@ -11,7 +11,7 @@ class RandomlyFail < Velveteen::Worker
   self.rate_limit_queue = "velveteen_general_tokens"
 
   def perform
-    if message.data[:job].even? && rand > 0.5
+    if message.data["job"].even? && rand > 0.5
       raise "Randomly failed"
     else
       logger.info(

--- a/lib/velveteen/parse_message.rb
+++ b/lib/velveteen/parse_message.rb
@@ -1,7 +1,7 @@
 module Velveteen
   class ParseMessage
     def self.call(body:, delivery_info:, properties:)
-      data = JSON.parse(body, symbolize_names: true)
+      data = JSON.parse(body)
 
       Message.new(
         body: body,

--- a/spec/velveteen/parse_message_spec.rb
+++ b/spec/velveteen/parse_message_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Velveteen::ParseMessage do
       properties: properties
     )
 
-    expect(message.data).to eq(foo: "bar")
+    expect(message.data).to eq("foo" => "bar")
     expect(message.headers).to eq(headers)
     expect(message.body).to eq(body)
     expect(message.delivery_info).to eq(delivery_info)

--- a/spec/velveteen/worker_spec.rb
+++ b/spec/velveteen/worker_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Velveteen::Worker do
 
   describe "#publish" do
     it "publishes the message" do
-      message = Velveteen::Message.new(data: {foo: "bar"}, headers: {})
+      message = Velveteen::Message.new(data: {"foo" => "bar"}, headers: {})
       worker = TestPublishingWorker.new(message: message)
       queue = Velveteen::Config.channel.queue("")
       queue.bind(
@@ -29,11 +29,11 @@ RSpec.describe Velveteen::Worker do
 
     it "passes along headers and appends new headers" do
       message = Velveteen::Message.new(
-        data: {foo: "bar"},
-        headers: {baz: "qux"}
+        data: {"foo" => "bar"},
+        headers: {"baz" => "qux"}
       )
       worker = TestPublishingWorker.new(message: message)
-      worker.test_headers = {name: "fred"}
+      worker.test_headers = {"name" => "fred"}
       queue = Velveteen::Config.channel.queue("")
       queue.bind(
         Velveteen::Config.exchange,
@@ -43,16 +43,16 @@ RSpec.describe Velveteen::Worker do
       worker.perform
 
       _, properties, _ = queue.pop
-      expect(properties[:headers]).to eq(baz: "qux", name: "fred")
+      expect(properties[:headers]).to eq("baz" => "qux", "name" => "fred")
     end
 
     it "does not pass along reserved RabbitMQ headers" do
       message = Velveteen::Message.new(
-        data: {foo: "bar"},
-        headers: {"x-death": [{count: 1}]}
+        data: {"foo" => "bar"},
+        headers: {"x-death" => [{"count" => 1}]}
       )
       worker = TestPublishingWorker.new(message: message)
-      worker.test_headers = {foo: "bar"}
+      worker.test_headers = {"foo" => "bar"}
       queue = Velveteen::Config.channel.queue("")
       queue.bind(
         Velveteen::Config.exchange,
@@ -62,7 +62,7 @@ RSpec.describe Velveteen::Worker do
       worker.perform
 
       _, properties, _ = queue.pop
-      expect(properties[:headers]).to eq(foo: "bar")
+      expect(properties[:headers]).to eq("foo" => "bar")
     end
   end
 


### PR DESCRIPTION
Using Symbol keys in `Message#data` has been confusing because
`Message#headers` (which is the same object from Bunny) uses String
keys. In an effort to remove that confusion, this commit updates the
message parsing to produce String keys, so that `data` and `headers` are
consistent with each other.

Resolves #13 