### PR TITLE
Add worker timeout

### DIFF
--- a/lib/velveteen.rb
+++ b/lib/velveteen.rb
@@ -7,4 +7,5 @@ require "velveteen/version"
 module Velveteen
   class Error < StandardError; end
   class InvalidMessage < Error; end
+  class WorkerTimeout < Error; end
 end

--- a/lib/velveteen/config.rb
+++ b/lib/velveteen/config.rb
@@ -8,7 +8,8 @@ module Velveteen
         :error_handler,
         :exchange_name,
         :queue_class,
-        :schema_directory
+        :schema_directory,
+        :worker_timeout
       )
     end
 
@@ -30,5 +31,6 @@ module Velveteen
     end
 
     self.error_handler = ErrorHandlers::Reject
+    self.worker_timeout = 10
   end
 end

--- a/lib/velveteen/handle_message.rb
+++ b/lib/velveteen/handle_message.rb
@@ -1,18 +1,54 @@
+require "timeout"
 require "velveteen/take_token"
 
 module Velveteen
   class HandleMessage
-    def self.call(message:, worker_class:)
-      worker = worker_class.new(message: message)
+    def self.call(**kwargs)
+      new(**kwargs).call
+    end
 
+    def initialize(message:, worker_class:)
+      @message = message
+      @worker_class = worker_class
+    end
+
+    def call
+      rate_limit
+      perform_work
+      acknowledge_message
+    rescue => error
+      handle_error(error)
+    end
+
+    private
+
+    attr_reader :message, :worker_class
+
+    def rate_limit
       if worker.rate_limited?
         TakeToken.call(worker: worker)
       end
+    end
 
-      worker.perform
+    def worker
+      @worker ||= worker_class.new(message: message)
+    end
 
+    def perform_work
+      Timeout.timeout(Config.worker_timeout, WorkerTimeout, timeout_message) do
+        worker.perform
+      end
+    end
+
+    def timeout_message
+      "timed out after #{Config.worker_timeout}s"
+    end
+
+    def acknowledge_message
       Config.channel.ack(message.delivery_info.delivery_tag)
-    rescue => error
+    end
+
+    def handle_error(error)
       Config.error_handler.call(
         error: error,
         message: message,

--- a/spec/velveteen/handle_message_spec.rb
+++ b/spec/velveteen/handle_message_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe Velveteen::HandleMessage do
     end
   end
 
+  class FailingWorker < Velveteen::Worker
+    def perform
+      raise "Failed"
+    end
+  end
+
+  class StuckWorker < Velveteen::Worker
+    def perform
+      sleep 1
+    end
+  end
+
   it "invokes the given worker" do
     worker_instance = instance_double(
       TestWorker,
@@ -49,5 +61,45 @@ RSpec.describe Velveteen::HandleMessage do
     expect(Velveteen::TakeToken)
       .to have_received(:call).with(worker: worker_instance)
     expect(worker_instance).to have_received(:perform)
+  end
+
+  it "handles exceptions in the worker" do
+    errors = []
+    Velveteen::Config.error_handler = ->(**kwargs) {
+      errors << kwargs
+    }
+    message = instance_double(
+      Velveteen::Message,
+      delivery_info: double(delivery_tag: double)
+    )
+
+    described_class.call(message: message, worker_class: FailingWorker)
+
+    expect(errors.size).to eq 1
+    error = errors.first
+    expect(error[:error]).to be_a RuntimeError
+    expect(error[:message]).to eq message
+    expect(error[:worker_class]).to eq FailingWorker
+  end
+
+  it "times out workers" do
+    errors = []
+    Velveteen::Config.error_handler = ->(**kwargs) {
+      errors << kwargs
+    }
+    Velveteen::Config.worker_timeout = 0.1
+    message = instance_double(
+      Velveteen::Message,
+      delivery_info: double(delivery_tag: double)
+    )
+
+    described_class.call(message: message, worker_class: StuckWorker)
+
+    expect(errors.size).to eq 1
+    error = errors.first
+    expect(error[:error]).to be_a Velveteen::WorkerTimeout
+    expect(error[:error].message).to eq "timed out after 0.1s"
+    expect(error[:message]).to eq message
+    expect(error[:worker_class]).to eq StuckWorker
   end
 end


### PR DESCRIPTION
If a worker hangs for an extended amount of time, it can significantly slow
down or halt a pipeline. One way we can deal with that is to force the
worker to stop after a certain amount of time.

This uses Ruby's builtin Timeout class to cause an exception to be raised
when the limit, defaulted to 10 seconds, is reached.

Resolves #15 