### PR TITLE
Add publish schema

### DIFF
--- a/spec/schemas/velveteen.test.publish.json
+++ b/spec/schemas/velveteen.test.publish.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["foo"],
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}

--- a/spec/schemas/worker.test.tea.ordered.json
+++ b/spec/schemas/worker.test.tea.ordered.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["tea"],
+  "properties": {
+    "boba": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Message to publish is validated against a schema that matches the
routing key. Validation method looks for file that matches the routing
key with hyphens subbed for dots under the schema folder. Also updates
our test worker to handle when a published message is different from the
consumed one.

Co-authored-by: Derrick Carr <derrick@thoughtbot.com>

TODO: 
- [ ] Update Readme

- [ ] Remove message_schema for consumed message validation and also base off of routing keys
- [ ] Refactor test workers. Currenlty we're adding new workers for additional cases. We may want to autogenerate them or have a few that users can re-use. This will happen after we remove message_schema for consumed message

Addresses Issue https://github.com/thoughtbot/velveteen/issues/12