### PR TITLE
Using routing key for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ When using Velveteen in particular, try to follow:
 
 ## Message validation
 
-Velveteen can validate incoming messages with a JSON Schema.
+Velveteen can validate incoming messages with a JSON Schema. The schema that we use has a file path that matches the routing key.
 
 ```ruby
 Velveteen::Config.schema_directory = "app/schemas"
 
 class FetchUserCommits < Velveteen::Worker
   ...
-  self.message_schema = "fetch_user_commits.json"
+  self.routing_key = "velveteen.fetch_user_commits"
 
   def perform
     # do something with the GitHub API

--- a/example/worker.rb
+++ b/example/worker.rb
@@ -7,7 +7,6 @@ Velveteen::Config.schema_directory = "example/schemas"
 
 class RandomlyFail < Velveteen::Worker
   self.routing_key = "velveteen.fail.randomly"
-  self.message_schema = "randomly_fail.json"
   self.rate_limit_queue = "velveteen_general_tokens"
 
   def perform

--- a/lib/velveteen/worker.rb
+++ b/lib/velveteen/worker.rb
@@ -7,7 +7,7 @@ module Velveteen
     attr_reader :message
 
     class << self
-      attr_accessor :message_schema, :rate_limit_queue, :routing_key
+      attr_accessor :rate_limit_queue, :routing_key
     end
 
     def initialize(message:)
@@ -64,15 +64,10 @@ module Velveteen
       File.expand_path(schema_file_path, Config.schema_directory)
     end
 
-    def message_schema
-      if self.class.message_schema
-        File.expand_path(self.class.message_schema, Config.schema_directory)
-      end
-    end
-
     def maybe_validate_message!
-      if message_schema
-        errors = JSON::Validator.fully_validate(message_schema, message.data)
+      if routing_key
+        schema = generate_schema(routing_key)
+        errors = JSON::Validator.fully_validate(schema, message.data)
 
         if errors.any?
           raise InvalidMessage, errors.join("\n")

--- a/lib/velveteen/worker.rb
+++ b/lib/velveteen/worker.rb
@@ -13,7 +13,7 @@ module Velveteen
     def initialize(message:)
       @message = message
 
-      maybe_validate_message!
+      validate_message!
     end
 
     def self.queue_name
@@ -64,14 +64,12 @@ module Velveteen
       File.expand_path(schema_file_path, Config.schema_directory)
     end
 
-    def maybe_validate_message!
-      if routing_key
-        schema = generate_schema(routing_key)
-        errors = JSON::Validator.fully_validate(schema, message.data)
+    def validate_message!
+      schema = generate_schema(routing_key)
+      errors = JSON::Validator.fully_validate(schema, message.data)
 
-        if errors.any?
-          raise InvalidMessage, errors.join("\n")
-        end
+      if errors.any?
+        raise InvalidMessage, errors.join("\n")
       end
     end
 

--- a/spec/velveteen/handle_message_spec.rb
+++ b/spec/velveteen/handle_message_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe Velveteen::HandleMessage do
   end
 
   class FailingWorker < Velveteen::Worker
+    self.routing_key = "velveteen.test.publish"
+
     def perform
       raise "Failed"
     end
   end
 
   class StuckWorker < Velveteen::Worker
+    self.routing_key = "velveteen.test.publish"
+
     def perform
       sleep 1
     end
@@ -72,6 +76,7 @@ RSpec.describe Velveteen::HandleMessage do
       Velveteen::Message,
       delivery_info: double(delivery_tag: double)
     )
+    allow(message).to receive(:data).and_return({foo: "bar"})
 
     described_class.call(message: message, worker_class: FailingWorker)
 
@@ -92,6 +97,7 @@ RSpec.describe Velveteen::HandleMessage do
       Velveteen::Message,
       delivery_info: double(delivery_tag: double)
     )
+    allow(message).to receive(:data).and_return({foo: "bar"})
 
     described_class.call(message: message, worker_class: StuckWorker)
 

--- a/spec/velveteen/worker_spec.rb
+++ b/spec/velveteen/worker_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Velveteen::Worker do
 
   class TestPublishingWorker < described_class
     attr_accessor :test_headers
+    self.routing_key = "velveteen.test.publish"
 
     def perform
       publish(
@@ -130,6 +131,7 @@ RSpec.describe Velveteen::Worker do
 
   class TestValidatesPayloadWorker < described_class
     attr_reader :payload
+    self.routing_key = "velveteen.test.publish"
 
     def initialize(message:, payload: nil)
       super(message: message)

--- a/spec/velveteen/worker_spec.rb
+++ b/spec/velveteen/worker_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Velveteen::Worker do
   end
 
   class TestSchemaWorker < described_class
-    self.message_schema = "test-schema-worker.json"
+    self.routing_key = "velveteen.test.publish"
   end
 
   class TestPublishingWorker < described_class


### PR DESCRIPTION
Use file matching the routing key instead of message schema to validate messages on consumption.

Addresses https://github.com/thoughtbot/velveteen/issues/25